### PR TITLE
Fix &alist usage

### DIFF
--- a/yequake.el
+++ b/yequake.el
@@ -192,7 +192,7 @@ See Info node `(elisp)Frame Parameters'."
         (select-frame-set-input-focus visible-frame)
         (setq yequake-focused t))
     ;; Frame doesn't exist: make it.
-    (-let* (((&alist '_x '_y 'width 'height 'left 'top 'buffer-fns 'alpha 'frame-parameters) frame)
+    (-let* (((&alist 'width width 'height height 'left left 'top top 'buffer-fns buffer-fns 'alpha alpha 'frame-parameters frame-parameters) frame)
             ((monitor-x monitor-y monitor-width monitor-height) (mapcar #'floor (alist-get 'geometry (frame-monitor-attributes))))
             (frame-width (cl-typecase width
                            (integer width)


### PR DESCRIPTION
Hey alphapapa, I ran into an issue trying to run your awesome package.

Installed from melpa, calling yequake-toggle results in an error:

    (setq yequake-frames
      '(("Yequake & scratch" .
         ((width . 0.75)
          (height . 0.5)
          (alpha . 0.95)
          (buffer-fns . ("*Messages*"
                         split-window-horizontally
                         "*scratch*"))
          (frame-parameters . ((undecorated . t)))))))

    (yequake-toggle "Yequake & scratch")


    setq: Wrong type argument: listp, 0.75

I am *not* familiar with -let*, or the dash.el in general. However, I skimmed through the readme on Magnars' repo & couldn't understand how the usage of &alist in yequake.el meshed with the documentation. I tried to implement the line based on my understanding of the documentation...and it appears to work now for me?

It's fairly likely that I'm misunderstanding something here! If so, I apologize for the spurious pull request.