### PR TITLE
Prevent yequake from tampering with windows in other frames

### DIFF
--- a/yequake.el
+++ b/yequake.el
@@ -212,9 +212,9 @@ See Info node `(elisp)Frame Parameters'."
                                                  (cons 'width (cons 'text-pixels frame-width))
                                                  (cons 'height (cons 'text-pixels frame-height))
                                                  (cons 'user-position t))))))
-      (delete-other-windows)
       (select-frame new-frame)
       (select-frame-set-input-focus new-frame)
+      (delete-other-windows)
       (add-hook 'focus-in-hook #'yequake--focus-in)
       (add-hook 'focus-out-hook #'yequake--focus-out)
       (setq yequake-recent-frame-name name


### PR DESCRIPTION
Right now when i open yequake it actually closes all the windows in the emacs frame that i'm working with, not in the one that it creates.

This PR fixes it