### PR TITLE
Make sure the function pointer of 'org-switch-to-buffer-other-window' is set.

### DIFF
--- a/yequake.el
+++ b/yequake.el
@@ -263,6 +263,7 @@ hook.
 Note: if another Yequake frame is toggled before the capture is
 finalized, when the capture is finalized, the wrong Yequake frame
 will be toggled."
+  (require 'org)
   (let* ((remove-hook-fn (lambda ()
                            (remove-hook 'org-capture-after-finalize-hook #'yequake-retoggle))))
     (add-hook 'org-capture-after-finalize-hook remove-hook-fn)


### PR DESCRIPTION
If org-mode has not yet been loaded when yequake-org-capture is run it will only
be required as part of org-capture's autoload. That means that the function
pointer of org-switch-to-buffer-other-window is nil by the time the switch
happens, thus nil is also the value that will be restored by cl-letf*.

By manually loading org we make sure that the function pointer is set correctly
before the switch happens. Doing so has no impact on performance since the
org-capture autoload would do it anyway.